### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,8 @@
 name: Android CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/SonryP/VitaMote/security/code-scanning/1](https://github.com/SonryP/VitaMote/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout@v4` step requires `contents: read` to check out the repository.
- The `actions/upload-artifact@v4` step requires `contents: read` to upload artifacts.

We will set `contents: read` as the only permission, as no other permissions are required for this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
